### PR TITLE
Fix README.md errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ input values. In order from left to right, using hash '#' characters as shown in
 1. Input:<br>
 1131<br>
 Output:<br>
-    
-    
-    #
+```
+>   #
     # ####
+```
     
    
 In particular, notice the spaces before the newlines on the first two lines. They are necessary.
@@ -31,14 +31,14 @@ In particular, notice the spaces before the newlines on the first two lines. The
 345<br>
 Output:<br>
     
-    
+```
     
     #
     ##
     ###
     ###
     ###
-    
+``` 
     
 3. Input:<br>
 0 3 0 4 5<br>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ input values. In order from left to right, using hash '#' characters as shown in
 1131<br>
 Output:<br>
 ```
->   #
+    #
     # ####
 ```
     
@@ -32,7 +32,6 @@ In particular, notice the spaces before the newlines on the first two lines. The
 Output:<br>
     
 ```
-    
     #
     ##
     ###

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A standard terminal window is 80 character-columns across. If we limit the numbe
 2. The input is guaranteed to be well-formed.
 3. The input contains no more than 80 values.
 4. On standard output, render a simple vertical column graph representation of the
-input values, in order left to right, using hash '#' characters as shown in the examples below. The number of hashes printed in each column should be equal to the corresponding input value.
+input values. In order from left to right, using hash '#' characters as shown in the examples below. The number of hashes printed in each column should be equal to the corresponding input value.
 5. The area above a completed column should be filled with space characters.
 6. Ignore empty lines. Do not output a column for an empty line.
 7. The entire graph must end with a newline character.


### PR DESCRIPTION
- Break one sentence into two short sentences
- Fix the display problem for the first two example outputs
fix #1 